### PR TITLE
Package not installed when repositoryPath is set to a relative path above solution folder

### DIFF
--- a/src/resharper-nuget/NuGetApi.cs
+++ b/src/resharper-nuget/NuGetApi.cs
@@ -137,9 +137,10 @@ namespace JetBrains.ReSharper.Plugins.NuGet
             // the package is installed one directory below the repository. Just a small crack in the black box.
             // (We can pass "All" as the package source, rather than the repository path, but that would give
             // us an aggregate of the current package sources, rather than using the local repo as a source)
-            var repositoryPath = Path.GetDirectoryName(metadata.InstallPath);
+			var installPath = Path.GetFullPath(metadata.InstallPath);
+			var repositoryPath = Path.GetDirectoryName(installPath);
             vsPackageInstaller.InstallPackage(repositoryPath, vsProject, metadata.Id, (Version)null, false);
-            installedLocation = metadata.InstallPath;
+			installedLocation = installPath;
 
             // Successfully installed, we handled it
             return true;
@@ -149,7 +150,7 @@ namespace JetBrains.ReSharper.Plugins.NuGet
         {
             return (from p in vsPackageInstallerServices.GetInstalledPackages()
                     from l in assemblyLocations
-                    where l.FullPath.StartsWith(p.InstallPath, StringComparison.InvariantCultureIgnoreCase)
+					where l.FullPath.StartsWith(Path.GetFullPath(p.InstallPath), StringComparison.InvariantCultureIgnoreCase)
                     select p).FirstOrDefault();
         }
 


### PR DESCRIPTION
If the repositoryPath is set to, for instance, ..\packages the packages do not get installed.
